### PR TITLE
Stats and chat

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,6 +3,8 @@ import { TranslateService } from '@ngx-translate/core';
 import { Platform } from 'ionic-angular';
 import { take } from 'rxjs/operators/take';
 import { LanguageProvider } from '@providers/language/language';
+import { LiveConfigurationProvider } from '@providers/live-configuration/live-configuration';
+import { StatReporterProvider } from '@providers/stat-reporter/stat-reporter';
 import { Language } from '@models/language';
 
 @Component({
@@ -26,7 +28,9 @@ export class MyApp implements OnInit, OnDestroy {
 
   constructor(
     private languageProvider: LanguageProvider,
+    private liveConfigurationProvider: LiveConfigurationProvider,
     private platform: Platform,
+    private statReporterProvider: StatReporterProvider,
     private translate: TranslateService,
   ) {}
 
@@ -36,6 +40,9 @@ export class MyApp implements OnInit, OnDestroy {
    * @return void
    */
   ngOnInit() {
+    this.liveConfigurationProvider.init().pipe(
+      take(1)
+    ).subscribe(()  =>  this.statReporterProvider.collectStats = this.liveConfigurationProvider.collectingStats);
     this.translate.setDefaultLang('en');
     this.languageProvider.getLanguage().pipe(take(1)).subscribe((language: Language) => {
       this.currentLanguage = language;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { MyApp } from '@app/app.component';
 import { LanguagePopoverComponent } from '@components/language-popover/language-popover';
 import { TocPopoverComponent } from '@components/toc-popover/toc-popover';
 import { LanguageProvider } from '@providers/language/language';
+import { StatReporterProvider } from '../providers/stat-reporter/stat-reporter';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { LanguageProvider } from '@providers/language/language';
   providers: [
     {provide: ErrorHandler, useClass: IonicErrorHandler},
     LanguageProvider,
+    StatReporterProvider,
   ]
 })
 export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { LanguagePopoverComponent } from '@components/language-popover/language-
 import { TocPopoverComponent } from '@components/toc-popover/toc-popover';
 import { LanguageProvider } from '@providers/language/language';
 import { StatReporterProvider } from '../providers/stat-reporter/stat-reporter';
+import { LiveConfigurationProvider } from '../providers/live-configuration/live-configuration';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { StatReporterProvider } from '../providers/stat-reporter/stat-reporter';
     {provide: ErrorHandler, useClass: IonicErrorHandler},
     LanguageProvider,
     StatReporterProvider,
+    LiveConfigurationProvider,
   ]
 })
 export class AppModule {}

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -10,6 +10,8 @@ export const environment = {
   assetPath: 'assets/content/{LANG}/',
   // Path to the languages file
   languagePath: 'assets/content/languages.json',
+  // The API endpoint to push viewership stats
+  reportingEndpoint: '',
   // Are we using a production version?
   isProduction: false,
 };

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -10,6 +10,8 @@ export const environment = {
   assetPath: 'assets/content/{LANG}/',
   // Path to the languages file
   languagePath: 'assets/content/languages.json',
+  // Path to the live configuration file
+  liveConfigFile: 'assets/content/config.json',
   // The API endpoint to push viewership stats
   reportingEndpoint: '',
   // Are we using a production version?

--- a/src/interfaces/av-player-item.interface.ts
+++ b/src/interfaces/av-player-item.interface.ts
@@ -15,6 +15,10 @@ export interface AvPlayerItem {
    */
   posterUrl: string;
   /**
+   * The slug identifier for the item
+   */
+  slug: string;
+  /**
    * The type of item
    */
   type: 'audio' | 'video';

--- a/src/interfaces/viewer-item.interface.ts
+++ b/src/interfaces/viewer-item.interface.ts
@@ -22,4 +22,8 @@ export interface ViewerItem {
    * The title of the item
    */
   title: string;
+  /**
+   * The media type of the item
+   */
+  type: string;
 }

--- a/src/interfaces/viewer-item.interface.ts
+++ b/src/interfaces/viewer-item.interface.ts
@@ -15,6 +15,10 @@ export interface ViewerItem {
    */
   filePath: string;
   /**
+   * The slug identifier for the item
+   */
+  slug: string;
+  /**
    * The title of the item
    */
   title: string;

--- a/src/pages/av-player/av-player.html
+++ b/src/pages/av-player/av-player.html
@@ -1,35 +1,37 @@
 <ion-content>
-  <div id="video-player-wrapper" [hidden]="current === null || current?.type !== 'video'">
-    <div class="overlay" [hidden]="!showOverlay">
-      <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
+  <ng-container *ngIf="current">
+    <div id="video-player-wrapper" [hidden]="current?.type !== 'video'">
+      <div class="overlay" [hidden]="!showOverlay">
+        <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
+      </div>
+      <video [src]="current?.url" controls [autoplay]="current?.type === 'video'" [poster]="current?.posterUrl" #videoPlayer>
+        {{ 'UNSUPPORTED_TEXT' | translate }}
+      </video>
     </div>
-    <video [src]="current?.url" controls [autoplay]="current?.type === 'video'" [poster]="current?.posterUrl" #videoPlayer>
-      {{ 'UNSUPPORTED_TEXT' | translate }}
-    </video>
-  </div>
-  <div id="audio-player-wrapper" [hidden]="current === null || current?.type !== 'audio'">
-    <div class="overlay" [hidden]="!showOverlay">
-      <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
+    <div id="audio-player-wrapper" [hidden]="current?.type !== 'audio'">
+      <div class="overlay" [hidden]="!showOverlay">
+        <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
+      </div>
+      <div id="audio-poster" [ngStyle]="{ 'background-image': 'url(' + current?.posterUrl + ')'}" #audioPoster></div>
+      <audio [src]="current?.url" controls [autoplay]="current?.type === 'audio'" #audioPlayer>
+        {{ 'UNSUPPORTED_TEXT' | translate }}
+      </audio>
     </div>
-    <div id="audio-poster" [ngStyle]="{ 'background-image': 'url(' + current?.posterUrl + ')'}" #audioPoster></div>
-    <audio [src]="current?.url" controls [autoplay]="current?.type === 'audio'" #audioPlayer>
-      {{ 'UNSUPPORTED_TEXT' | translate }}
-    </audio>
-  </div>
-  <div id="secondary-controls">
-    <ion-grid>
-      <ion-row>
-        <ion-col col-2 text-center offset-3>
-          <button icon-only ion-button clear color="primary" (click)="previousEpisode()" [disabled]="isFirstItem()"><ion-icon name="skip-backward"></ion-icon></button>
-        </ion-col>
-        <ion-col col-2 text-center>
-          <button icon-only ion-button clear color="primary" (click)="play()" *ngIf="!isPlaying"><ion-icon name="play"></ion-icon></button>
-          <button icon-only ion-button clear color="primary" (click)="pause()" *ngIf="isPlaying"><ion-icon name="pause"></ion-icon></button>
-        </ion-col>
-        <ion-col col-2 text-center>
-          <button icon-only ion-button clear color="primary" (click)="nextEpisode()" [disabled]="isLastItem()"><ion-icon name="skip-forward"></ion-icon></button>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
-  </div>
+    <div id="secondary-controls">
+      <ion-grid>
+        <ion-row>
+          <ion-col col-2 text-center offset-3>
+            <button icon-only ion-button clear color="primary" (click)="previousEpisode()" [disabled]="isFirstItem()"><ion-icon name="skip-backward"></ion-icon></button>
+          </ion-col>
+          <ion-col col-2 text-center>
+            <button icon-only ion-button clear color="primary" (click)="play()" *ngIf="!isPlaying"><ion-icon name="play"></ion-icon></button>
+            <button icon-only ion-button clear color="primary" (click)="pause()" *ngIf="isPlaying"><ion-icon name="pause"></ion-icon></button>
+          </ion-col>
+          <ion-col col-2 text-center>
+            <button icon-only ion-button clear color="primary" (click)="nextEpisode()" [disabled]="isLastItem()"><ion-icon name="skip-forward"></ion-icon></button>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </div>
+  </ng-container>
 </ion-content>

--- a/src/pages/base-viewer/base-viewer.ts
+++ b/src/pages/base-viewer/base-viewer.ts
@@ -139,15 +139,16 @@ export class BaseViewerPage {
   /**
    * Report the viewing of an item
    *
-   * @param  item The item being viewed
-   * @return      The item received
+   * @param  item         The item being viewed
+   * @param  interaction  How are they interacting
+   * @return              The item received
    */
-  reportView(item: ViewerItem): Observable<ViewerItem> {
+  reportView(item: ViewerItem, interaction = 'view'): Observable<ViewerItem> {
     if (!item) {
       return of(null);
     }
     return this.languageProvider.getLanguage().pipe(
-      mergeMap((lang: Language) =>  this.statReporterProvider.report(item.slug, 'view', lang.twoLetterCode, item.type).pipe(map(() =>  item)))
+      mergeMap((lang: Language) =>  this.statReporterProvider.report(item.slug, interaction, lang.twoLetterCode, item.type).pipe(map(() =>  item)))
     );
   }
 

--- a/src/pages/base-viewer/base-viewer.ts
+++ b/src/pages/base-viewer/base-viewer.ts
@@ -1,9 +1,16 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { NavController, NavParams, ViewController } from 'ionic-angular';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { map } from 'rxjs/operators/map';
+import { mergeMap } from 'rxjs/operators/mergeMap';
 import { take } from 'rxjs/operators/take';
 import { DownloadFileProvider } from '@providers/download-file/download-file';
+import { LanguageProvider } from '@providers/language/language';
 import { NavParamsDataStoreProvider } from '@providers/nav-params-data-store/nav-params-data-store';
+import { StatReporterProvider } from '@providers/stat-reporter/stat-reporter';
 import { ViewerItem } from '@interfaces/viewer-item.interface';
+import { Language } from '@models/language';
 
 /**
  * A base viewer for the viewers to inherit from.  Stores common code.
@@ -42,8 +49,10 @@ export class BaseViewerPage {
   constructor(
     protected dataStore: NavParamsDataStoreProvider,
     protected downloadFileProvider: DownloadFileProvider,
+    protected languageProvider: LanguageProvider,
     protected navController: NavController,
     protected navParams: NavParams,
+    protected statReporterProvider: StatReporterProvider,
     protected viewController: ViewController,
   ) {
   }
@@ -125,6 +134,21 @@ export class BaseViewerPage {
         animate: true,
       });
     }
+  }
+
+  /**
+   * Report the viewing of an item
+   *
+   * @param  item The item being viewed
+   * @return      The item received
+   */
+  reportView(item: ViewerItem): Observable<ViewerItem> {
+    if (!item) {
+      return of(null);
+    }
+    return this.languageProvider.getLanguage().pipe(
+      mergeMap((lang: Language) =>  this.statReporterProvider.report(item.slug, 'view', lang.twoLetterCode, item.type).pipe(map(() =>  item)))
+    );
   }
 
 }

--- a/src/pages/chat/chat.ts
+++ b/src/pages/chat/chat.ts
@@ -1,8 +1,11 @@
 import { Component, ViewChild } from '@angular/core';
 import { IonicPage, NavController, NavParams, Content } from 'ionic-angular';
 import { HttpClient } from '@angular/common/http';
+import { map } from 'rxjs/operators/map';
+import { take } from 'rxjs/operators/take';
 import { Storage } from '@ionic/storage';
 import { Observable } from 'rxjs/Observable';
+import { LiveConfigurationProvider } from '@providers/live-configuration/live-configuration';
 import { generateNickname } from '@helpers/utilities';
 import 'rxjs/add/observable/interval';
 import 'rxjs/add/operator/mergeMap';
@@ -28,6 +31,7 @@ export class ChatPage {
   url = '';
 
   constructor(
+    private liveConfigurationProvider: LiveConfigurationProvider,
     private storage: Storage,
     public navCtrl: NavController,
     public navParams: NavParams,
@@ -69,6 +73,18 @@ export class ChatPage {
       (err) => {
         console.log(err);
       });
+  }
+
+  /**
+   * Ionic view lifecycle to check if the user can enter this view.
+   *
+   * @return Promise<boolean> is allowed to access
+   */
+  ionViewCanEnter() {
+    return this.liveConfigurationProvider.init().pipe(
+      take(1),
+      map(()  =>  this.liveConfigurationProvider.allowsChat)
+    ).toPromise();
   }
 
   goHome() {

--- a/src/pages/epub-viewer/epub-viewer.ts
+++ b/src/pages/epub-viewer/epub-viewer.ts
@@ -180,6 +180,17 @@ export class EpubViewerPage extends BaseViewerPage implements BaseViewerPageInte
   flatten(arr: Array<any>) {
     return [].concat(...arr.map(v => [v, ...this.flatten(v.subitems)]));
   }
+
+  /**
+   * The user wants to download the file
+   * @param  filePath The file path
+   * @return  void
+   */
+  downloadFile(filePath: string) {
+    super.downloadFile(filePath);
+    this.reportView(this.item, 'download').pipe(take(1)).subscribe();
+  }
+
   /**
    * Load the file
    *

--- a/src/pages/epub-viewer/epub-viewer.ts
+++ b/src/pages/epub-viewer/epub-viewer.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
 import { Events, IonicPage, NavController, NavParams, Platform, PopoverController, ViewController } from 'ionic-angular';
+import { take } from 'rxjs/operators/take';
 import { Book } from 'epubjs';
 import { BaseViewerPage } from '@pages/base-viewer/base-viewer';
 import { BaseViewerPageInterface } from '@interfaces/base-viewer.interface';
 import { DownloadFileProvider } from '@providers/download-file/download-file';
+import { LanguageProvider } from '@providers/language/language';
 import { NavParamsDataStoreProvider } from '@providers/nav-params-data-store/nav-params-data-store';
+import { StatReporterProvider } from '@providers/stat-reporter/stat-reporter';
 import { TocItem } from '@interfaces/toc-item.interface';
 import { ViewerItem } from '@interfaces/viewer-item.interface';
 import { TocPopoverComponent } from '@components/toc-popover/toc-popover';
@@ -86,13 +89,17 @@ export class EpubViewerPage extends BaseViewerPage implements BaseViewerPageInte
     protected platform: Platform,
     protected popoverController: PopoverController,
     protected viewController: ViewController,
+    languageProvider: LanguageProvider,
+    statReporterProvider: StatReporterProvider,
   ) {
     super(
       dataStore,
       downloadFileProvider,
+      languageProvider,
       navController,
       navParams,
-      viewController
+      statReporterProvider,
+      viewController,
     );
   }
 
@@ -180,6 +187,7 @@ export class EpubViewerPage extends BaseViewerPage implements BaseViewerPageInte
    */
   loadFile() {
     this.item = this.firstItem;
+    this.reportView(this.item).pipe(take(1)).subscribe();
     this.book = new Book(this.item.filePath);
     this.rendition = this.book.renderTo('book', { width: '100%', height: '100%' });
     this.rendition.themes.fontSize(`${this.fontSize}%`);

--- a/src/pages/h5p-viewer/h5p-viewer.ts
+++ b/src/pages/h5p-viewer/h5p-viewer.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { IonicPage } from 'ionic-angular';
+import { take } from 'rxjs/operators/take';
 import { H5P } from 'h5p-standalone';
 import { BaseViewerPage } from '@pages/base-viewer/base-viewer';
 import { BaseViewerPageInterface } from '@interfaces/base-viewer.interface';
@@ -35,6 +36,7 @@ export class H5pViewerPage extends BaseViewerPage implements BaseViewerPageInter
    */
   loadFile() {
     this.item = this.firstItem;
+    this.reportView(this.item).pipe(take(1)).subscribe();
     const options = {
       h5pJsonPath: this.item.filePath,
       frameJs: 'assets/h5p/frame.bundle.js',

--- a/src/pages/h5p-viewer/h5p-viewer.ts
+++ b/src/pages/h5p-viewer/h5p-viewer.ts
@@ -30,6 +30,16 @@ export class H5pViewerPage extends BaseViewerPage implements BaseViewerPageInter
   item: ViewerItem = null;
 
   /**
+   * The user wants to download the file
+   * @param  filePath The file path
+   * @return  void
+   */
+  downloadFile(filePath: string) {
+    super.downloadFile(filePath);
+    this.reportView(this.item, 'download').pipe(take(1)).subscribe();
+  }
+
+  /**
    * Load the requested file
    *
    * @return void

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -64,8 +64,8 @@
   <app-footer></app-footer>
 </ion-content>
 
-<ion-fab right bottom>
-  <button ion-button icon-only (click)="goChat()">
+<ion-fab right bottom [hidden]="!allowsChat">
+  <button ion-fab icon-only mini (click)="goChat()">
       <ion-icon name="chatbubbles"></ion-icon>
   </button>
 </ion-fab>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -4,6 +4,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { mergeMap } from 'rxjs/operators/mergeMap';
 import { take } from 'rxjs/operators/take';
 import { LanguageProvider } from '@providers/language/language';
+import { LiveConfigurationProvider } from '@providers/live-configuration/live-configuration';
 import { MediaProvider } from '@providers/media/media';
 import { GroupedMedia } from '@interfaces/grouped-media.interface';
 import { Language } from '@models/language';
@@ -16,6 +17,11 @@ import { LanguagePopoverComponent } from '@components/language-popover/language-
   templateUrl: 'home.html'
 })
 export class HomePage {
+  /**
+   * Is chat enabled?
+   */
+  allowsChat = true;
+
   /**
    * Our media to display
    */
@@ -56,6 +62,7 @@ export class HomePage {
     private mediaProvider: MediaProvider,
     private navController: NavController,
     private languageProvider: LanguageProvider,
+    private liveConfigurationProvider: LiveConfigurationProvider,
     private popoverController: PopoverController,
     private translateService: TranslateService,
   ) {}
@@ -68,6 +75,7 @@ export class HomePage {
   ionViewWillEnter() {
     this.languageProvider.getLanguage().pipe(take(1)).subscribe((lang: Language) => this.loadData(lang));
     this.languageOnChangeStream$ = this.languageProvider.onLanguageChange.subscribe((lang: Language) => this.loadData(lang));
+    this.liveConfigurationProvider.init().pipe(take(1)).subscribe(()  =>  this.allowsChat = this.liveConfigurationProvider.allowsChat);
   }
 
   /**

--- a/src/pages/image-viewer/image-viewer.ts
+++ b/src/pages/image-viewer/image-viewer.ts
@@ -34,6 +34,16 @@ export class ImageViewerPage extends BaseViewerPage implements BaseViewerPageInt
   @ViewChild(Slides) slides: Slides;
 
   /**
+   * The user wants to download the file
+   * @param  filePath The file path
+   * @return  void
+   */
+  downloadFile(filePath: string) {
+    super.downloadFile(filePath);
+    this.reportView(this.item, 'download').pipe(take(1)).subscribe();
+  }
+
+  /**
    * Load the requested file
    *
    * @return void

--- a/src/pages/image-viewer/image-viewer.ts
+++ b/src/pages/image-viewer/image-viewer.ts
@@ -1,5 +1,6 @@
 import { Component, ViewChild } from '@angular/core';
 import { IonicPage, Slides } from 'ionic-angular';
+import { take } from 'rxjs/operators/take';
 import { BaseViewerPage } from '@pages/base-viewer/base-viewer';
 import { BaseViewerPageInterface } from '@interfaces/base-viewer.interface';
 import { ViewerItem } from '@interfaces/viewer-item.interface';
@@ -39,6 +40,7 @@ export class ImageViewerPage extends BaseViewerPage implements BaseViewerPageInt
    */
   loadFile() {
     this.item = this.firstItem;
+    this.reportView(this.item).pipe(take(1)).subscribe();
     // Put photos in correct order starting with isFirst going to the last.
     const firstIndex = this.items.findIndex((item: ViewerItem)  =>  item.isFirst);
     const firstItems: Array<ViewerItem> = this.items.slice(0, firstIndex);
@@ -54,6 +56,7 @@ export class ImageViewerPage extends BaseViewerPage implements BaseViewerPageInt
   slideChanged() {
     let currentIndex = this.slides.getActiveIndex();
     this.item = this.images[currentIndex];
+    this.reportView(this.item).pipe(take(1)).subscribe();
   }
 
 }

--- a/src/pages/media-detail/media-detail.html
+++ b/src/pages/media-detail/media-detail.html
@@ -40,7 +40,7 @@
       <p>{{ media?.desc }}</p>
       <div id="single-media-actions" *ngIf="media?.episodes.length === 0">
         <ion-buttons end>
-          <button ion-button clear icon-only (click)="downloadFile(media?.downloadPath)">
+          <button ion-button clear icon-only (click)="downloadFile(media?.downloadPath, media?.mediaType, media?.slug)">
             <ion-icon name="download" color="primary"></ion-icon>
           </button>
           <button ion-button clear icon-only (click)="playMedia()" [hidden]="!hasViewer(media?.mediaType)">
@@ -67,7 +67,7 @@
               </ion-col>
               <ion-col col-6>
                 <ion-buttons end>
-                  <button ion-button clear icon-only (click)="downloadFile(episode?.downloadPath)">
+                  <button ion-button clear icon-only (click)="downloadFile(episode?.downloadPath, episode?.mediaType, episode?.slug)">
                     <ion-icon name="download" color="primary"></ion-icon>
                   </button>
                   <button ion-button clear icon-only (click)="playEpisode(episode)" [hidden]="!hasViewer(episode?.mediaType, true)">

--- a/src/pages/media-detail/media-detail.ts
+++ b/src/pages/media-detail/media-detail.ts
@@ -195,6 +195,7 @@ export class MediaDetailPage {
           isFirst: playFirst,
           slug: episode.slug,
           title: episode.title,
+          type: episode.mediaType,
         };
       });
     }
@@ -226,6 +227,7 @@ export class MediaDetailPage {
         isFirst: true,
         slug: this.media.slug,
         title: this.media.title,
+        type: this.media.mediaType,
       };
     }
     this.openViewer(this.media, [item]);

--- a/src/pages/media-detail/media-detail.ts
+++ b/src/pages/media-detail/media-detail.ts
@@ -182,6 +182,7 @@ export class MediaDetailPage {
           url: episode.filePath,
           playFirst: playFirst,
           posterUrl: episode.imagePath,
+          slug: episode.slug,
           type: episode.mediaType,
         };
       });
@@ -192,6 +193,7 @@ export class MediaDetailPage {
           downloadPath: episode.downloadPath,
           filePath: episode.filePath,
           isFirst: playFirst,
+          slug: episode.slug,
           title: episode.title,
         };
       });
@@ -214,6 +216,7 @@ export class MediaDetailPage {
         url: this.media.filePath,
         playFirst: true,
         posterUrl: this.media.imagePath,
+        slug: this.media.slug,
         type: this.media.mediaType,
       };
     } else {
@@ -221,6 +224,7 @@ export class MediaDetailPage {
         downloadPath: this.media.downloadPath,
         filePath: this.media.filePath,
         isFirst: true,
+        slug: this.media.slug,
         title: this.media.title,
       };
     }

--- a/src/pages/media-detail/media-detail.ts
+++ b/src/pages/media-detail/media-detail.ts
@@ -269,7 +269,9 @@ export class MediaDetailPage {
   }
 
   /**
-   * Open the appropriate viewer for the media
+   * Open the appropriate viewer for the media.
+   * NOTE: We only report on HTML because it opens a new window.  All view reporting
+   * should be added to viewer.  This allows recording multiple views.
    *
    * @param  resource   The resource that we are retrieving
    * @param  items      An array of items in order of play
@@ -280,7 +282,9 @@ export class MediaDetailPage {
     if ((resource.mediaType === 'video') || (resource.mediaType === 'audio')) {
       this.navController.push('av-player', { items: items, slug: resource.slug });
     } else if (resource.mediaType === 'html') {
-      window.open(resource.filePath);
+      this.statReporterProvider.report(resource.slug, 'view', this.currentLanguage.twoLetterCode, resource.mediaType).pipe(
+        take(1)
+      ).subscribe(() => window.open(resource.filePath));
     } else if (viewer !== '') {
       this.navController.push(viewer, { items: items, slug: resource.slug });
     }

--- a/src/pages/media-detail/media-detail.ts
+++ b/src/pages/media-detail/media-detail.ts
@@ -174,9 +174,9 @@ export class MediaDetailPage {
    * @return         void
    */
   playEpisode(current: Episode) {
-    const viewer = this.getViewer(current.mediaType);
+    let items: Array<AvPlayerItem|ViewerItem> = null;
     if ((current.mediaType === 'video') || (current.mediaType === 'audio')) {
-      const items = this.media.episodes.map((episode: Episode) => {
+      items = <Array<AvPlayerItem>> this.media.episodes.map((episode: Episode) => {
         const playFirst = (episode.title === current.title);
         return {
           url: episode.filePath,
@@ -185,11 +185,8 @@ export class MediaDetailPage {
           type: episode.mediaType,
         };
       });
-      this.navController.push('av-player', { items: items, slug: this.slug });
-    }  else if (current.mediaType === 'html') {
-      window.open(current.filePath);
-    } else if (viewer !== '') {
-      const items: Array<ViewerItem> = this.media.episodes.map((episode: Episode) => {
+    } else {
+      items = <Array<ViewerItem>> this.media.episodes.map((episode: Episode) => {
         const playFirst = (episode.title === current.title);
         return {
           downloadPath: episode.downloadPath,
@@ -198,8 +195,8 @@ export class MediaDetailPage {
           title: episode.title,
         };
       });
-      this.navController.push(viewer, { items: items, slug: this.slug });
     }
+    this.openViewer(current, items);
   }
 
   /**
@@ -211,26 +208,23 @@ export class MediaDetailPage {
     if (!this.media) {
       return;
     }
-    const viewer = this.getViewer(this.media.mediaType);
+    let item: AvPlayerItem|ViewerItem = null;
     if ((this.media.mediaType === 'video') || (this.media.mediaType === 'audio')) {
-      const item: AvPlayerItem = {
+      item = <AvPlayerItem> {
         url: this.media.filePath,
         playFirst: true,
         posterUrl: this.media.imagePath,
         type: this.media.mediaType,
       };
-      this.navController.push('av-player', { items: [item], slug: this.slug });
-    } else if (this.media.mediaType === 'html') {
-      window.open(this.media.filePath);
-    } else if (viewer !== '') {
-      const item: ViewerItem = {
+    } else {
+      item = <ViewerItem> {
         downloadPath: this.media.downloadPath,
         filePath: this.media.filePath,
         isFirst: true,
         title: this.media.title,
       };
-      this.navController.push(viewer, { items: [item], slug: this.slug });
     }
+    this.openViewer(this.media, [item]);
   }
 
   /**
@@ -272,6 +266,24 @@ export class MediaDetailPage {
       .get(this.slug)
       .pipe(take(1))
       .subscribe((media: Media) => this.media = media);
+  }
+
+  /**
+   * Open the appropriate viewer for the media
+   *
+   * @param  resource   The resource that we are retrieving
+   * @param  items      An array of items in order of play
+   * @return void
+   */
+  private openViewer(resource: Media|Episode, items: Array<AvPlayerItem|ViewerItem>) {
+    const viewer = this.getViewer(resource.mediaType);
+    if ((resource.mediaType === 'video') || (resource.mediaType === 'audio')) {
+      this.navController.push('av-player', { items: items, slug: resource.slug });
+    } else if (resource.mediaType === 'html') {
+      window.open(resource.filePath);
+    } else if (viewer !== '') {
+      this.navController.push(viewer, { items: items, slug: resource.slug });
+    }
   }
 
 }

--- a/src/pages/pdf-viewer/pdf-viewer.ts
+++ b/src/pages/pdf-viewer/pdf-viewer.ts
@@ -138,6 +138,16 @@ export class PdfViewerPage extends BaseViewerPage implements BaseViewerPageInter
   }
 
   /**
+   * The user wants to download the file
+   * @param  filePath The file path
+   * @return  void
+   */
+  downloadFile(filePath: string) {
+    super.downloadFile(filePath);
+    this.reportView(this.item, 'download').pipe(take(1)).subscribe();
+  }
+
+  /**
    * Load the requested file
    *
    * @return void

--- a/src/pages/pdf-viewer/pdf-viewer.ts
+++ b/src/pages/pdf-viewer/pdf-viewer.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, NgZone, TemplateRef, ViewChild, ViewContainerRef, ViewRef } from '@angular/core';
 import { Content, IonicPage, NavController, NavParams, ViewController } from 'ionic-angular';
+import { take } from 'rxjs/operators/take';
 import * as PDFJS from 'pdfjs-dist/webpack.js';
 import { PDFPageProxy, PDFPageViewport, PDFRenderTask } from 'pdfjs-dist';
 import { BaseViewerPage } from '@pages/base-viewer/base-viewer';
@@ -7,7 +8,9 @@ import { BaseViewerPageInterface } from '@interfaces/base-viewer.interface';
 import { PagePosition } from '@interfaces/page-position.interface';
 import { PageState } from '@interfaces/page-state.interface';
 import { DownloadFileProvider } from '@providers/download-file/download-file';
+import { LanguageProvider } from '@providers/language/language';
 import { NavParamsDataStoreProvider } from '@providers/nav-params-data-store/nav-params-data-store';
+import { StatReporterProvider } from '@providers/stat-reporter/stat-reporter';
 import { ViewerItem } from '@interfaces/viewer-item.interface';
 
 /**
@@ -109,15 +112,19 @@ export class PdfViewerPage extends BaseViewerPage implements BaseViewerPageInter
     protected downloadFileProvider: DownloadFileProvider,
     protected navController: NavController,
     protected navParams: NavParams,
-    protected zone: NgZone,
     protected viewController: ViewController,
+    protected zone: NgZone,
+    languageProvider: LanguageProvider,
+    statReporterProvider: StatReporterProvider,
   ) {
     super(
       dataStore,
       downloadFileProvider,
+      languageProvider,
       navController,
       navParams,
-      viewController
+      statReporterProvider,
+      viewController,
     );
   }
 
@@ -137,6 +144,7 @@ export class PdfViewerPage extends BaseViewerPage implements BaseViewerPageInter
    */
   loadFile() {
     this.item = this.firstItem;
+    this.reportView(this.item).pipe(take(1)).subscribe();
     /**
      * Check if the view is larger than the new PDF page.  If so, load additional pages
      */

--- a/src/pages/text-viewer/text-viewer.ts
+++ b/src/pages/text-viewer/text-viewer.ts
@@ -55,6 +55,16 @@ export class TextViewerPage extends BaseViewerPage implements BaseViewerPageInte
   }
 
   /**
+   * The user wants to download the file
+   * @param  filePath The file path
+   * @return  void
+   */
+  downloadFile(filePath: string) {
+    super.downloadFile(filePath);
+    this.reportView(this.item, 'download').pipe(take(1)).subscribe();
+  }
+
+  /**
    * load the requested file
    *
    * @return void

--- a/src/pages/text-viewer/text-viewer.ts
+++ b/src/pages/text-viewer/text-viewer.ts
@@ -3,7 +3,9 @@ import { IonicPage, NavController, NavParams, ViewController } from 'ionic-angul
 import { take } from 'rxjs/operators/take';
 import { DownloadFileProvider } from '@providers/download-file/download-file';
 import { FileUtilityProvider } from '@providers/file-utility/file-utility';
+import { LanguageProvider } from '@providers/language/language';
 import { NavParamsDataStoreProvider } from '@providers/nav-params-data-store/nav-params-data-store';
+import { StatReporterProvider } from '@providers/stat-reporter/stat-reporter';
 import { BaseViewerPage } from '@pages/base-viewer/base-viewer';
 import { BaseViewerPageInterface } from '@interfaces/base-viewer.interface';
 import { ViewerItem } from '@interfaces/viewer-item.interface';
@@ -38,13 +40,17 @@ export class TextViewerPage extends BaseViewerPage implements BaseViewerPageInte
     protected navController: NavController,
     protected navParams: NavParams,
     protected viewController: ViewController,
+    languageProvider: LanguageProvider,
+    statReporterProvider: StatReporterProvider,
   ) {
     super(
       dataStore,
       downloadFileProvider,
+      languageProvider,
       navController,
       navParams,
-      viewController
+      statReporterProvider,
+      viewController,
     );
   }
 
@@ -55,6 +61,7 @@ export class TextViewerPage extends BaseViewerPage implements BaseViewerPageInte
    */
   loadFile() {
     this.item = this.firstItem;
+    this.reportView(this.item).pipe(take(1)).subscribe();
     this.fileUtilityProvider.read(this.item.filePath).pipe(take(1)).subscribe((content: string) =>  this.content = content.replace(/(?:\r\n|\r|\n)/g, '<br>'));
   }
 

--- a/src/providers/av-player-data-store/av-player-data-store.spec.ts
+++ b/src/providers/av-player-data-store/av-player-data-store.spec.ts
@@ -16,24 +16,28 @@ describe('AvPlayerDataStoreProvider', () => {
       playFirst: false,
       url: 'first/item.mp4',
       posterUrl: 'first/item.jpg',
+      slug: 'first',
       type: 'video',
     },
     {
       playFirst: true,
       url: 'second/item.mp4',
       posterUrl: 'second/item.jpg',
+      slug: 'second',
       type: 'video',
     },
     {
       playFirst: false,
       url: 'third/item.mp4',
       posterUrl: 'third/item.jpg',
+      slug: 'third',
       type: 'video',
     },
     {
       playFirst: false,
       url: 'fourth/item.mp4',
       posterUrl: 'fourth/item.jpg',
+      slug: 'fourth',
       type: 'video',
     },
   ];

--- a/src/providers/language/language.spec.ts
+++ b/src/providers/language/language.spec.ts
@@ -207,7 +207,8 @@ describe('LanguageProvider', () => {
           expect(storage.get).toHaveBeenCalledWith(languageProvider.storageKey);
           expect(translate.getBrowserCultureLang).not.toHaveBeenCalled();
         });
-        app.httpMock.expectNone(environment.languagePath);
+        const request = app.httpMock.expectOne(environment.languagePath);
+        request.flush(mockedResponse);
       })));
 
       it('should get the preferred language if not in database', async(inject([LanguageProvider], (languageProvider) => {

--- a/src/providers/live-configuration/live-configuration.spec.ts
+++ b/src/providers/live-configuration/live-configuration.spec.ts
@@ -1,0 +1,51 @@
+import { async, inject } from '@angular/core/testing';
+import {} from 'jasmine';
+import { take } from 'rxjs/operators/take';
+import { AppTestingModule } from '../../../test-config/app-testing-module';
+import { LiveConfigurationProvider } from './live-configuration';
+import { environment } from '@env';
+
+describe('LiveConfigurationProvider', ()  =>  {
+  let app: AppTestingModule;
+
+  beforeEach(() => {
+      app = new AppTestingModule();
+      app.configure([], [
+        LiveConfigurationProvider,
+      ], true);
+  });
+
+  describe('loading', ()  =>  {
+
+    it('should load settings from file', async(inject([LiveConfigurationProvider], (liveConfigurationProvider)  =>  {
+      const response: any = {
+        disable_openwell_chat: true,
+        disable_stats: true,
+      };
+      const request = app.httpMock.expectOne(environment.liveConfigFile);
+      request.flush(response);
+      expect(liveConfigurationProvider.allowsChat).toBeFalsy();
+      expect(liveConfigurationProvider.collectingStats).toBeFalsy();
+    })));
+
+    it('should keep defaults if file is missing', async(inject([LiveConfigurationProvider], (liveConfigurationProvider)  =>  {
+      const response = { status: 400, statusText: 'Bad Request' };
+      const request = app.httpMock.expectOne(environment.liveConfigFile);
+      request.flush('', response);
+      expect(liveConfigurationProvider.allowsChat).toBeTruthy();
+      expect(liveConfigurationProvider.collectingStats).toBeTruthy();
+    })));
+
+    it('should handle different key for chat', async(inject([LiveConfigurationProvider], (liveConfigurationProvider)  =>  {
+      const response: any = {
+        disable_chat: true,
+      };
+      const request = app.httpMock.expectOne(environment.liveConfigFile);
+      request.flush(response);
+      expect(liveConfigurationProvider.allowsChat).toBeFalsy();
+      expect(liveConfigurationProvider.collectingStats).toBeTruthy();
+    })));
+
+  });
+
+});

--- a/src/providers/live-configuration/live-configuration.spec.ts
+++ b/src/providers/live-configuration/live-configuration.spec.ts
@@ -22,28 +22,34 @@ describe('LiveConfigurationProvider', ()  =>  {
         disable_openwell_chat: true,
         disable_stats: true,
       };
+      liveConfigurationProvider.init().pipe(take(1)).subscribe(() =>  {
+        expect(liveConfigurationProvider.allowsChat).toBeFalsy();
+        expect(liveConfigurationProvider.collectingStats).toBeFalsy();
+      });
       const request = app.httpMock.expectOne(environment.liveConfigFile);
       request.flush(response);
-      expect(liveConfigurationProvider.allowsChat).toBeFalsy();
-      expect(liveConfigurationProvider.collectingStats).toBeFalsy();
     })));
 
     it('should keep defaults if file is missing', async(inject([LiveConfigurationProvider], (liveConfigurationProvider)  =>  {
       const response = { status: 400, statusText: 'Bad Request' };
+      liveConfigurationProvider.init().pipe(take(1)).subscribe(() =>  {
+        expect(liveConfigurationProvider.allowsChat).toBeTruthy();
+        expect(liveConfigurationProvider.collectingStats).toBeTruthy();
+      });
       const request = app.httpMock.expectOne(environment.liveConfigFile);
       request.flush('', response);
-      expect(liveConfigurationProvider.allowsChat).toBeTruthy();
-      expect(liveConfigurationProvider.collectingStats).toBeTruthy();
     })));
 
     it('should handle different key for chat', async(inject([LiveConfigurationProvider], (liveConfigurationProvider)  =>  {
       const response: any = {
         disable_chat: true,
       };
+      liveConfigurationProvider.init().pipe(take(1)).subscribe(() =>  {
+        expect(liveConfigurationProvider.allowsChat).toBeFalsy();
+        expect(liveConfigurationProvider.collectingStats).toBeTruthy();
+      });
       const request = app.httpMock.expectOne(environment.liveConfigFile);
       request.flush(response);
-      expect(liveConfigurationProvider.allowsChat).toBeFalsy();
-      expect(liveConfigurationProvider.collectingStats).toBeTruthy();
     })));
 
   });

--- a/src/providers/live-configuration/live-configuration.ts
+++ b/src/providers/live-configuration/live-configuration.ts
@@ -18,6 +18,11 @@ import { environment } from '@env';
 export class LiveConfigurationProvider {
 
   /**
+   * Have we finished loading the file?
+   */
+  private isInitialized = false;
+
+  /**
    * Do we allow chatting?
    */
   private chatEnabled = true;
@@ -65,6 +70,7 @@ export class LiveConfigurationProvider {
         if (response && response.hasOwnProperty('disable_stats')) {
           this.statsEnabled = (!response.disable_stats);
         }
+        this.isInitialized = true;
         return null;
     }));
   }
@@ -76,6 +82,9 @@ export class LiveConfigurationProvider {
    */
   private load(): Observable<any> {
     if (environment.liveConfigFile === '') {
+      return of(null);
+    }
+    if (this.isInitialized) {
       return of(null);
     }
     return this.http.get(environment.liveConfigFile).pipe(catchError(() =>  of(null)));

--- a/src/providers/live-configuration/live-configuration.ts
+++ b/src/providers/live-configuration/live-configuration.ts
@@ -1,0 +1,78 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { catchError } from 'rxjs/operators/catchError';
+import { of } from 'rxjs/observable/of';
+import { take } from 'rxjs/operators/take';
+import { environment } from '@env';
+
+/**
+ * This provider loads configurations in assets directory if it exists.
+ * This provides a way to set specific configurations without building the code base.
+ * We currently support the following keys:
+ *
+ * disable_openwell_chat/disable_chat: Disables the chat functionality.
+ * disable_stats: Disable the collecting of stats.
+ */
+@Injectable()
+export class LiveConfigurationProvider {
+
+  /**
+   * Do we allow chatting?
+   */
+  private chatEnabled = true;
+
+  /**
+   * Are we collecting stats?
+   */
+  private statsEnabled = true;
+
+  constructor(
+    private http: HttpClient
+  ) {
+    this.load();
+  }
+
+  /**
+   * Do we allow chatting?
+   *
+   * @return yes|no
+   */
+  get allowsChat(): boolean {
+    return this.chatEnabled;
+  }
+
+  /**
+   * Do we collect stats?
+   *
+   * @return yes|no
+   */
+  get collectingStats(): boolean {
+    return this.statsEnabled;
+  }
+
+  /**
+   * Load the configuration file
+   *
+   * @return void
+   */
+  private load() {
+    if (environment.liveConfigFile === '') {
+      return;
+    }
+    this.http.get(environment.liveConfigFile).pipe(
+      take(1),
+      catchError(() =>  of(null)),
+    ).subscribe((response: any) =>  {
+      if (response && response.hasOwnProperty('disable_openwell_chat')) {
+        this.chatEnabled = (!response.disable_openwell_chat);
+      }
+      if (response && response.hasOwnProperty('disable_chat')) {
+        this.chatEnabled = (!response.disable_chat);
+      }
+      if (response && response.hasOwnProperty('disable_stats')) {
+        this.statsEnabled = (!response.disable_stats);
+      }
+    });
+  }
+
+}

--- a/src/providers/stat-reporter/stat-reporter.spec.ts
+++ b/src/providers/stat-reporter/stat-reporter.spec.ts
@@ -1,0 +1,49 @@
+import { async, inject } from '@angular/core/testing';
+import {} from 'jasmine';
+import { take } from 'rxjs/operators/take';
+import { AppTestingModule } from '../../../test-config/app-testing-module';
+import { StatReporterProvider } from './stat-reporter';
+import { environment } from '@env';
+
+describe('StatReporterProvider', () =>  {
+  let app: AppTestingModule;
+
+  describe('methods', ()  =>  {
+
+    describe('report()', () =>  {
+
+      beforeEach(() => {
+          app = new AppTestingModule();
+          app.configure([], [
+            StatReporterProvider,
+          ], true);
+      });
+
+      it('should report the interaction', async(inject([StatReporterProvider], (statReporterProvider) =>  {
+        statReporterProvider.report('best-cat-videos', 'download', 'en', 'video').pipe(take(1)).subscribe((success: boolean)  =>  {
+          expect(success).toBeTruthy();
+        });
+
+        const request = app.httpMock.expectOne({method: 'PUT', url: environment.reportingEndpoint});
+        const body = request.request.body;
+        expect(body.interactionType).toEqual('download');
+        expect(body.mediaIdentifier).toEqual('best-cat-videos');
+        expect(body.mediaLanguage).toEqual('en');
+        expect(body.mediaProvider).toEqual('');
+        expect(body.mediaType).toEqual('video');
+        request.flush({});
+      })));
+
+      it('should report nothing if wrong interaction provided', async(inject([StatReporterProvider], (statReporterProvider) =>  {
+        statReporterProvider.report('best-dog-videos', 'played', 'en', 'video').pipe(take(1)).subscribe((success: boolean)  =>  {
+          expect(success).toBeFalsy();
+        });
+
+        app.httpMock.expectNone({method: 'PUT', url: environment.reportingEndpoint});
+      })));
+
+    });
+
+  });
+
+});

--- a/src/providers/stat-reporter/stat-reporter.spec.ts
+++ b/src/providers/stat-reporter/stat-reporter.spec.ts
@@ -20,6 +20,7 @@ describe('StatReporterProvider', () =>  {
       });
 
       it('should report the interaction', async(inject([StatReporterProvider], (statReporterProvider) =>  {
+        statReporterProvider.collectStats = true;
         statReporterProvider.report('best-cat-videos', 'download', 'en', 'video').pipe(take(1)).subscribe((success: boolean)  =>  {
           expect(success).toBeTruthy();
         });
@@ -35,7 +36,17 @@ describe('StatReporterProvider', () =>  {
       })));
 
       it('should report nothing if wrong interaction provided', async(inject([StatReporterProvider], (statReporterProvider) =>  {
+        statReporterProvider.collectStats = true;
         statReporterProvider.report('best-dog-videos', 'played', 'en', 'video').pipe(take(1)).subscribe((success: boolean)  =>  {
+          expect(success).toBeFalsy();
+        });
+
+        app.httpMock.expectNone({method: 'PUT', url: environment.reportingEndpoint});
+      })));
+
+      it('should report nothing if we are not collecting stats', async(inject([StatReporterProvider], (statReporterProvider)  =>  {
+        statReporterProvider.collectStats = false;
+        statReporterProvider.report('best-koala-videos', 'download', 'en', 'video').pipe(take(1)).subscribe((success: boolean)  =>  {
           expect(success).toBeFalsy();
         });
 

--- a/src/providers/stat-reporter/stat-reporter.ts
+++ b/src/providers/stat-reporter/stat-reporter.ts
@@ -12,6 +12,11 @@ import { environment } from '@env';
 @Injectable()
 export class StatReporterProvider {
 
+  /**
+   * Build the class
+   *
+   * @param http  Angular's http client
+   */
   constructor(
     private http: HttpClient
   ) {}

--- a/src/providers/stat-reporter/stat-reporter.ts
+++ b/src/providers/stat-reporter/stat-reporter.ts
@@ -11,6 +11,10 @@ import { environment } from '@env';
  */
 @Injectable()
 export class StatReporterProvider {
+  /**
+   * Do you want to collect stats?
+   */
+  collectStats = true;
 
   /**
    * Build the class
@@ -36,6 +40,9 @@ export class StatReporterProvider {
     language: string,
     mediaType: string,
   ): Observable<boolean> {
+    if (!this.collectStats) {
+      return of(false);
+    }
     if (environment.reportingEndpoint === '') {
       return of(false);
     }

--- a/src/providers/stat-reporter/stat-reporter.ts
+++ b/src/providers/stat-reporter/stat-reporter.ts
@@ -1,0 +1,55 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { catchError } from 'rxjs/operators/catchError';
+import { of } from 'rxjs/observable/of';
+import { map } from 'rxjs/operators/map';
+import { environment } from '@env';
+
+/**
+ * A provider that handles reporting viewership stats to the backend API.
+ */
+@Injectable()
+export class StatReporterProvider {
+
+  constructor(
+    private http: HttpClient
+  ) {}
+
+  /**
+   * Report interaction with the frontend
+   *
+   * @param  identifier   The media's identifier
+   * @param  interaction  The type of interaction (download or view)
+   * @param  language     The current language
+   * @param  mediaType    The type of media
+   * @return              Was it successful?
+   */
+  report(
+    identifier: string,
+    interaction: string,
+    language: string,
+    mediaType: string,
+  ): Observable<boolean> {
+    if (environment.reportingEndpoint === '') {
+      return of(false);
+    }
+    if (['download', 'view'].indexOf(interaction) === -1) {
+      return of(false);
+    }
+    const timestamp = Math.round((new Date()).getTime() / 1000);
+    const body = {
+      interactionType: interaction,
+      mediaIdentifier: identifier,
+      mediaLanguage: language,
+      mediaProvider: '',
+      mediaType: mediaType,
+      timestamp: timestamp,
+    };
+    return this.http.put(environment.reportingEndpoint, body).pipe(
+      map(()  =>  true),
+      catchError(() =>  of(false))
+    );
+  }
+
+}


### PR DESCRIPTION
We now provide a way to report when media is viewed or downloaded.  Also added a live configuration feature that allows the admin to disable chat and/or stat reporting by modifying the file **assets/content/config.json** without needing to rebuild the site. The file should look like this:

```
{
  "disable_openwell_chat": true,
  "disable_stats": false
}
```

This PR requires two fields to be added to **src/environments/environment.ts**:

- reportingEndpoint: The URL used for reporting. For example, **/admin/api/weblog**
- liveConfigFile: The live configuration file. For example, **assets/content/config.json**
