### PR TITLE
We Can Now Hide Branding in the Header

### DIFF
--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -16,10 +16,10 @@
 </ng-template>
 <ion-header>
   <ion-navbar class="with-logo" hideBackButton="true">
-    <div class="logo-wrapper" [hidden]="logo === ''">
+    <div class="logo-wrapper" [hidden]="(logo === '') || (!displaysBranding)">
       <img src="assets/{{ logo }}" />
     </div>
-    <ion-title>{{ 'APP_NAME' | translate }}</ion-title>
+    <ion-title [hidden]="!displaysBranding">{{ 'APP_NAME' | translate }}</ion-title>
     <ion-buttons end>
       <button ion-button icon-right (click)="openLanguagePopover($event)">
         {{ 'LANGUAGE_BUTTON' | translate }} <ion-icon name="cog"></ion-icon>

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -23,6 +23,11 @@ export class HomePage {
   allowsChat = true;
 
   /**
+   * Do we display the branded information?
+   */
+  displaysBranding = true;
+
+  /**
    * Our media to display
    */
   groups: GroupedMedia = {};
@@ -75,7 +80,10 @@ export class HomePage {
   ionViewWillEnter() {
     this.languageProvider.getLanguage().pipe(take(1)).subscribe((lang: Language) => this.loadData(lang));
     this.languageOnChangeStream$ = this.languageProvider.onLanguageChange.subscribe((lang: Language) => this.loadData(lang));
-    this.liveConfigurationProvider.init().pipe(take(1)).subscribe(()  =>  this.allowsChat = this.liveConfigurationProvider.allowsChat);
+    this.liveConfigurationProvider.init().pipe(take(1)).subscribe(()  =>  {
+      this.allowsChat = this.liveConfigurationProvider.allowsChat;
+      this.displaysBranding = this.liveConfigurationProvider.displayBranding;
+    });
   }
 
   /**

--- a/src/providers/live-configuration/live-configuration.ts
+++ b/src/providers/live-configuration/live-configuration.ts
@@ -23,6 +23,11 @@ export class LiveConfigurationProvider {
   private isInitialized = false;
 
   /**
+   * Do we want to display the logo and app name in the header?
+   */
+  private displayTheBranding = true;
+
+  /**
    * Do we allow chatting?
    */
   private chatEnabled = true;
@@ -46,6 +51,15 @@ export class LiveConfigurationProvider {
   }
 
   /**
+   * Do we want to display the branding?
+   * 
+   * @return yes|no
+   */
+  get displayBranding(): boolean {
+    return this.displayTheBranding;
+  }
+
+  /**
    * Do we collect stats?
    *
    * @return yes|no
@@ -61,17 +75,21 @@ export class LiveConfigurationProvider {
    */
   init(): Observable<void> {
     return this.load().pipe(map((response: any) =>  {
-        if (response && response.hasOwnProperty('disable_openwell_chat')) {
-          this.chatEnabled = (!response.disable_openwell_chat);
-        }
-        if (response && response.hasOwnProperty('disable_chat')) {
-          this.chatEnabled = (!response.disable_chat);
-        }
-        if (response && response.hasOwnProperty('disable_stats')) {
-          this.statsEnabled = (!response.disable_stats);
-        }
-        this.isInitialized = true;
-        return null;
+      console.log(response);
+      if (response && response.hasOwnProperty('disable_openwell_chat')) {
+        this.chatEnabled = (!response.disable_openwell_chat);
+      }
+      if (response && response.hasOwnProperty('disable_chat')) {
+        this.chatEnabled = (!response.disable_chat);
+      }
+      if (response && response.hasOwnProperty('disable_stats')) {
+        this.statsEnabled = (!response.disable_stats);
+      }
+      if (response && response.hasOwnProperty('hide_branding')) {
+        this.displayTheBranding = (!response.hide_branding);
+      }
+      this.isInitialized = true;
+      return null;
     }));
   }
 


### PR DESCRIPTION
To hide the logo and app name, we need to use live configuration.  Simply edit the file `assets/content/config.json` and set the following parameter:

```
{
    "hide_branding": true
}
```

That is it!

## Demo

![Screen Shot 2022-10-19 at 11 09 02 AM](https://user-images.githubusercontent.com/540521/196770896-c6947d9a-2e8e-45d0-85f8-4ab96dfb2f91.png)
