### PR TITLE
Fix an issue where tap gestures were unresponsive

### DIFF
--- a/src/pages/av-player/av-player.html
+++ b/src/pages/av-player/av-player.html
@@ -1,7 +1,7 @@
 <ion-content>
   <ng-container *ngIf="current">
     <div id="video-player-wrapper" [hidden]="current?.type !== 'video'">
-      <div class="overlay" [hidden]="!showOverlay">
+      <div id="exit-button" class=""text-right>
         <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
       </div>
       <video [src]="current?.url" controls [autoplay]="current?.type === 'video'" [poster]="current?.posterUrl" #videoPlayer>
@@ -9,7 +9,7 @@
       </video>
     </div>
     <div id="audio-player-wrapper" [hidden]="current?.type !== 'audio'">
-      <div class="overlay" [hidden]="!showOverlay">
+      <div id="exit-button" class=""text-right>
         <button icon-only ion-button clear color="primary" (click)="goBack()" class="close-btn"><ion-icon name="close"></ion-icon></button>
       </div>
       <div id="audio-poster" [ngStyle]="{ 'background-image': 'url(' + current?.posterUrl + ')'}" #audioPoster></div>

--- a/src/pages/av-player/av-player.scss
+++ b/src/pages/av-player/av-player.scss
@@ -1,11 +1,29 @@
 page-av-player {
+    .scroll-content {
+        overflow-y: hidden !important;
+    }
+    #exit-button {
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: 100;
+
+        .close-btn {
+            color: #ffffff;
+            font-size: 1.40em;
+        }
+    }
     #secondary-controls {
         height: 7%;
         max-height: 7%;
+        margin: 0 !important;
+        padding: 0 !important;
     }
     #audio-player-wrapper {
         height: 93%;
         position: relative;
+        margin: 0 !important;
+        padding: 0 !important;
 
         audio {
             height: 7%;
@@ -22,23 +40,11 @@ page-av-player {
         }
     }
 
-    .overlay {
-        background-color: rgba(0, 0, 0, 0.5);
-        width: 100%;
-        position: absolute;
-        right: 0;
-        text-align: right;
-        top: 0;
-        z-index: 100;
-
-        .close-btn {
-            color: #ffffff;
-        }
-    }
-
     #video-player-wrapper {
         height: 93%;
         position: relative;
+        margin: 0 !important;
+        padding: 0 !important;
 
         video {
             height: 100%;

--- a/src/pages/av-player/av-player.ts
+++ b/src/pages/av-player/av-player.ts
@@ -50,11 +50,6 @@ export class AvPlayerPage {
     isPlaying = true;
 
     /**
-     * Should we show the overlay?
-     */
-    showOverlay = false;
-
-    /**
      * The callback triggered when the audio/video ended.
      */
     private mediaEndedCallback: any = null;
@@ -68,11 +63,6 @@ export class AvPlayerPage {
      * The callback triggered when the audio/video is started.
      */
     private mediaPlayCallback: any = null;
-
-    /**
-     * The callback triggered when the audio/video is hovered/tapped.
-     */
-    private mediaEngagedCallback: any = null;
 
     /**
      * The slug for the previous page
@@ -118,20 +108,12 @@ export class AvPlayerPage {
       this.mediaEndedCallback = () => this.videoDidEnd();
       this.mediaPauseCallback = () => this.isPlaying = false;
       this.mediaPlayCallback = () => this.isPlaying = true;
-      this.mediaEngagedCallback = (event) => this.displayOverlay(event);
       this.videoPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
       this.audioPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
       this.videoPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
       this.audioPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
       this.videoPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
       this.audioPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
-
-      this.videoPlayer.nativeElement.addEventListener('touchstart', this.mediaEngagedCallback, false);
-      this.videoPlayer.nativeElement.addEventListener('mouseenter', this.mediaEngagedCallback, false);
-      this.audioPoster.nativeElement.addEventListener('touchstart', this.mediaEngagedCallback, false);
-      this.audioPoster.nativeElement.addEventListener('mouseenter', this.mediaEngagedCallback, false);
-      this.audioPlayer.nativeElement.addEventListener('touchstart', this.mediaEngagedCallback, false);
-      this.audioPlayer.nativeElement.addEventListener('mouseenter', this.mediaEngagedCallback, false);
     }
 
     /**
@@ -154,15 +136,6 @@ export class AvPlayerPage {
         this.videoPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
         this.audioPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
         this.mediaPlayCallback = null;
-      }
-      if (this.mediaEngagedCallback) {
-        this.videoPlayer.nativeElement.removeEventListener('touchstart', this.mediaEngagedCallback);
-        this.videoPlayer.nativeElement.removeEventListener('mouseenter', this.mediaEngagedCallback);
-        this.audioPoster.nativeElement.removeEventListener('touchstart', this.mediaEngagedCallback);
-        this.audioPoster.nativeElement.removeEventListener('mouseenter', this.mediaEngagedCallback);
-        this.audioPlayer.nativeElement.removeEventListener('touchstart', this.mediaEngagedCallback);
-        this.audioPlayer.nativeElement.removeEventListener('mouseenter', this.mediaEngagedCallback);
-        this.mediaEngagedCallback = null;
       }
     }
 
@@ -275,21 +248,6 @@ export class AvPlayerPage {
           this.current = prev;
         }
       });
-    }
-
-    /**
-     * Display the overlay for a set amount of seconds.
-     *
-     * @param   event   the event that triggered it
-     * @return void
-     */
-    displayOverlay(event) {
-      event.preventDefault();
-      if (this.showOverlay) {
-        return;
-      }
-      this.showOverlay = true;
-      setTimeout(() => this.showOverlay = false, 3000);
     }
 
     /**

--- a/src/pages/av-player/av-player.ts
+++ b/src/pages/av-player/av-player.ts
@@ -278,7 +278,6 @@ export class AvPlayerPage {
      * @return void
      */
     private setUpListeners() {
-      console.log('setUpListeners');
       if ((!this.videoPlayer) && (!this.audioPlayer)) {
         // We need to wait until the elements are visible
         setTimeout(() => this.setUpListeners(), 300);

--- a/src/pages/av-player/av-player.ts
+++ b/src/pages/av-player/av-player.ts
@@ -95,6 +95,7 @@ export class AvPlayerPage {
           this.goBack();
         } else {
           this.current = current;
+          this.setUpListeners();
         }
       });
     }
@@ -104,37 +105,29 @@ export class AvPlayerPage {
      *
      * @return void
      */
-    ionViewDidEnter() {
-      this.mediaEndedCallback = () => this.videoDidEnd();
-      this.mediaPauseCallback = () => this.isPlaying = false;
-      this.mediaPlayCallback = () => this.isPlaying = true;
-      this.videoPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
-      this.audioPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
-      this.videoPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
-      this.audioPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
-      this.videoPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
-      this.audioPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
-    }
-
-    /**
-     * Ionic view lifecycle
-     *
-     * @return void
-     */
     ionViewWillLeave() {
       if (this.mediaEndedCallback) {
-        this.videoPlayer.nativeElement.removeEventListener('ended', this.mediaEndedCallback);
-        this.audioPlayer.nativeElement.removeEventListener('ended', this.mediaEndedCallback);
+        if (this.current.type === 'audio') {
+          this.audioPlayer.nativeElement.removeEventListener('ended', this.mediaEndedCallback);
+        } else {
+          this.videoPlayer.nativeElement.removeEventListener('ended', this.mediaEndedCallback);
+        }
         this.mediaEndedCallback = null;
       }
       if (this.mediaPauseCallback) {
-        this.videoPlayer.nativeElement.removeEventListener('pause', this.mediaPauseCallback);
-        this.audioPlayer.nativeElement.removeEventListener('pause', this.mediaPauseCallback);
+        if (this.current.type === 'audio') {
+          this.audioPlayer.nativeElement.removeEventListener('pause', this.mediaPauseCallback);
+        } else {
+          this.videoPlayer.nativeElement.removeEventListener('pause', this.mediaPauseCallback); 
+        }
         this.mediaPauseCallback = null;
       }
       if (this.mediaPlayCallback) {
-        this.videoPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
-        this.audioPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
+        if (this.current.type === 'audio') {
+          this.audioPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
+        } else {
+          this.videoPlayer.nativeElement.removeEventListener('play', this.mediaPlayCallback);
+        }
         this.mediaPlayCallback = null;
       }
     }
@@ -277,6 +270,34 @@ export class AvPlayerPage {
       return this.languageProvider.getLanguage().pipe(
         mergeMap((lang: Language) =>  this.statReporterProvider.report(item.slug, 'view', lang.twoLetterCode, item.provider, item.type).pipe(map(() =>  item)))
       );
+    }
+
+    /**
+     * Set up all the listeners
+     *
+     * @return void
+     */
+    private setUpListeners() {
+      console.log('setUpListeners');
+      if ((!this.videoPlayer) && (!this.audioPlayer)) {
+        // We need to wait until the elements are visible
+        setTimeout(() => this.setUpListeners(), 300);
+        return;
+      }
+      this.mediaEndedCallback = () => this.videoDidEnd();
+      this.mediaPauseCallback = () => this.isPlaying = false;
+      this.mediaPlayCallback = () => this.isPlaying = true;
+      if (this.current.type === 'audio') {
+        this.isPlaying = (!this.audioPlayer.nativeElement.paused);
+        this.audioPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
+        this.audioPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
+        this.audioPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
+      } else {
+        this.isPlaying = (!this.videoPlayer.nativeElement.paused);
+        this.videoPlayer.nativeElement.addEventListener('play', this.mediaPlayCallback, false);
+        this.videoPlayer.nativeElement.addEventListener('pause', this.mediaPauseCallback, false);
+        this.videoPlayer.nativeElement.addEventListener('ended', this.mediaEndedCallback, false);
+      }
     }
 
 }


### PR DESCRIPTION
We were listening to tap gestures to show the exit button.  This was capturing the taps on the video.  We now just display an exit button.  All tap gestures belong to the HTML 5 elements now.  Also cleaned up attachment of event listeners.